### PR TITLE
Ensure export routines create directories before writing files

### DIFF
--- a/usernamechecker.py
+++ b/usernamechecker.py
@@ -297,13 +297,17 @@ def pretty_print(data: Dict[str, Any]) -> None:
 
 
 def export_json(path: str, data: Dict[str, Any]) -> None:
-    Path(path).write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
 
 
 def export_csv(path: str, data: Dict[str, Any]) -> None:
-    with open(path, "w", newline="", encoding="utf-8") as f:
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with open(p, "w", newline="", encoding="utf-8") as f:
         wr = csv.writer(f)
-        wr.writerow(["site", "available", "status", "url"]) 
+        wr.writerow(["site", "available", "status", "url"])
         for r in data["results"]:
             wr.writerow([r["site"], r["available"], r["status"], r["url"]])
 


### PR DESCRIPTION
## Summary
- create parent directories for JSON and CSV exports to prevent FileNotFoundError when paths include new folders

## Testing
- `python -m py_compile usernamechecker.py`
- `python - <<'PY'
import types, sys, tempfile
class DummySession: pass
class DummyConnector: pass
class DummyError(Exception): pass
sys.modules['aiohttp'] = types.SimpleNamespace(ClientSession=DummySession, TCPConnector=DummyConnector, ClientError=DummyError)
import usernamechecker
from pathlib import Path
root = Path(tempfile.mkdtemp())
usernamechecker.export_json(root/'nested'/'out.json', {'username': 'test', 'results': []})
usernamechecker.export_csv(root/'nested'/'out.csv', {'results': []})
print((root/'nested'/'out.json').exists(), (root/'nested'/'out.csv').exists())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b49c3af6808326b56f98df0bf21879